### PR TITLE
fix(tests): Re-enable MQTT and Postgres tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,20 @@ jobs:
     # run on a larger runner for more SSD/resource access
     runs-on: ubuntu-22.04-4core-spin
     if: ${{ github.repository_owner == 'spinframework' }}
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: spin_dev
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v3
 

--- a/tests/runtime-tests/tests/outbound-postgres-variable-permission/spin.toml
+++ b/tests/runtime-tests/tests/outbound-postgres-variable-permission/spin.toml
@@ -14,5 +14,5 @@ component = "test"
 
 [component.test]
 source = "%{source=outbound-postgres}"
-allowed_outbound_hosts = ["postgres://{{ pg_host }}:%{port=5432}"]
-environment = { DB_URL = "postgres://postgres:postgres@localhost:%{port=5432}/spin_dev" }
+allowed_outbound_hosts = ["postgres://{{ pg_host }}:5432"]
+environment = { DB_URL = "postgres://postgres:postgres@localhost:5432/spin_dev" }

--- a/tests/runtime-tests/tests/outbound-postgres/spin.toml
+++ b/tests/runtime-tests/tests/outbound-postgres/spin.toml
@@ -11,5 +11,5 @@ component = "test"
 
 [component.test]
 source = "%{source=outbound-postgres}"
-allowed_outbound_hosts = ["postgres://localhost:%{port=5432}"]
-environment = { DB_URL = "postgres://postgres:postgres@localhost:%{port=5432}/spin_dev" }
+allowed_outbound_hosts = ["postgres://localhost:5432"]
+environment = { DB_URL = "postgres://postgres:postgres@localhost:5432/spin_dev" }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -7,12 +7,7 @@ mod runtime_tests {
     // The macro inspects the tests directory and
     // generates individual tests for each one.
     test_codegen_macro::codegen_runtime_tests!(
-        ignore: [
-            // This test is flaky. Often gets "Connection reset by peer" errors.
-            // https://github.com/spinframework/spin/issues/2265
-            "outbound-postgres",
-            "outbound-postgres-variable-permission"
-        ]
+        ignore: []
     );
 
     fn run(test_path: PathBuf) {
@@ -28,7 +23,7 @@ mod runtime_tests {
 
     #[test]
     fn conformance_tests() -> anyhow::Result<()> {
-        let config = conformance_tests::Config::new("canary").ignore("outbound-mqtt");
+        let config = conformance_tests::Config::new("canary");
         let conclusion = conformance_tests::run_tests(config, move |test| {
             conformance::run_test(test, &spin_binary())
         })?;

--- a/tests/test-components/components/outbound-postgres/src/lib.rs
+++ b/tests/test-components/components/outbound-postgres/src/lib.rs
@@ -32,8 +32,8 @@ impl Component {
         ensure_matches!(rowset.rows[0][2], postgres::DbValue::Time((h, m, s, ns)) if h == 4 && m == 5 && s == 6 && ns == 789_000_000);
         ensure_matches!(rowset.rows[0][3], postgres::DbValue::Datetime((y, _, _, h, _, _, ns)) if y == 1989 && h == 1 && ns == 0);
         ensure_matches!(rowset.rows[1][1], postgres::DbValue::Date((y, m, d)) if y == 2525 && m == 12 && d == 25);
-        ensure_matches!(rowset.rows[1][2], postgres::DbValue::Time((h, m, s, ns)) if h == 14 && m == 15 && s == 16 && ns == 17);
-        ensure_matches!(rowset.rows[1][3], postgres::DbValue::Datetime((y, _, _, h, _, _, ns)) if y == 1989 && h == 1 && ns == 4);
+        ensure_matches!(rowset.rows[1][2], postgres::DbValue::Time((h, m, s, ns)) if h == 14 && m == 15 && s == 16 && ns == 0);
+        ensure_matches!(rowset.rows[1][3], postgres::DbValue::Datetime((y, _, _, h, _, _, ns)) if y == 1989 && h == 1 && ns == 1000);
 
         let rowset = ensure_ok!(nullable(&conn));
         ensure!(rowset.rows.iter().all(|r| r.len() == 1));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Re-enabled previously ignored runtime and conformance tests for outbound PostgreSQL and MQTT.
  - Updated test configurations to use a fixed PostgreSQL port instead of variable substitution.
  - Adjusted test assertions for PostgreSQL date and time nanosecond values.

- **Chores**
  - Enhanced CI workflow by adding an MQTT service container alongside PostgreSQL for integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->